### PR TITLE
Remove unnecessary urllib quoting

### DIFF
--- a/dot_kernel/kernel.py
+++ b/dot_kernel/kernel.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import base64
-import urllib
 import subprocess
 from . import imgsize
 from graphviz import Source
@@ -29,7 +28,7 @@ class DotKernel(Kernel):
         # send response to web client
         if not silent:
             if not has_error:
-                data = urllib.parse.quote(base64.b64encode(png_src))
+                data = base64.b64encode(png_src)
                 width, height = imgsize.get_png_size(png_src)
                 stream_content = {
                     "metadata": {"image/png": {"width": width, "height": height}},

--- a/dot_kernel/kernel.py
+++ b/dot_kernel/kernel.py
@@ -28,11 +28,13 @@ class DotKernel(Kernel):
         # send response to web client
         if not silent:
             if not has_error:
-                data = base64.b64encode(png_src)
+                # Note: JSON encoding requires a string, so after base64 encoding the data
+                # we must decode the resulting bytes
+                data_string = base64.b64encode(png_src).decode("utf-8")
                 width, height = imgsize.get_png_size(png_src)
                 stream_content = {
                     "metadata": {"image/png": {"width": width, "height": height}},
-                    "data": {"image/png": data},
+                    "data": {"image/png": data_string},
                 }
 
                 self.send_response(self.iopub_socket, "display_data", stream_content)


### PR DESCRIPTION
I think the `urllib.parse.quote` here should be removed, for the following reasons:

1) If you want to do URL-safe base64 encoding, there's a built-in function `base64.urlsafe_b64encode` for that.
2) In any case I don't think the URL-safe variant is needed at all; you can just use "standard" base64 encoding and it still works.

The Jupyter Notebook frontend seems to tolerate any of these, but my own custom Jupyter frontend was getting confused by this. I'm not totally sure what encoding you're supposed to use for MIME-encoded images, since a number of [variants](https://en.wikipedia.org/wiki/Base64#Variants_summary_table) exist. So I'm curious why you added this call in the first place? Thanks!