### PR TITLE
Fix the paint of install kernel

### DIFF
--- a/bin/install-dot-kernel
+++ b/bin/install-dot-kernel
@@ -1,3 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+from os.path import join
+from subprocess import call
 
-jupyter kernelspec install dot_kernel_spec --user
+from pkg_resources import get_distribution
+
+if __name__ == '__main__':
+    dist = get_distribution('dot-kernel')
+    where = join(dist.location, 'dot_kernel_spec')
+    call(['jupyter', 'kernelspec', 'install', '--user', where])

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author_email="laixintao1995@163.com",
     description="Writing dot language and render in jupyter.",
     packages=find_packages(),
+    package_data={'': '*.json'},
     install_requires=["graphviz", "jupyter"],
     scripts=['bin/install-dot-kernel']
 )


### PR DESCRIPTION
It is frustrating to install the kernel when executing `install-dot-kernel`. There will always be a `FileNotFoundError` if the `dot-kernell` is installed by `pip install dot_kernel`.

> FileNotFoundError : [Errno 2] No such file or directory: 'dot_kernel_spec'

## Reason

`dot_kernel_spec` will not be installed with `pip`, so Jupyter can not find it.

This can only be fixed by clone this repository and execute `install-dot-kernel` in it, which means the `pip` installed package can not work alone.

Related issues:

- #3
- #4

## Solution

My solution is to pack the `dot_kernel_spec` directory with the `kernel.json` to the package `dot-kernel`. Change the `install-dot-kernel` to find and install it.