### PR TITLE
Enable long_description for pypi.org

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+long_description = file: readme.md
+long_description_content_type = text/markdown


### PR DESCRIPTION
The proejct description in <https://pypi.org/project/dot-kernel/> is empty. This PR may help.

There may be issues for the pictures. It depends on the pypi.org, and can be fixed by absolute links in GitHub.